### PR TITLE
fix: remove reconcile checksum rate limmiter, add reconciler timeout

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,13 +19,6 @@ jobs:
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 1.20.x
-      - name: Restore Go cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: Tests
         run: make test
       - name: Send go coverage report

--- a/.github/workflows/pr-build.yaml
+++ b/.github/workflows/pr-build.yaml
@@ -55,13 +55,6 @@ jobs:
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 1.20.x
-      - name: Restore Go cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: fmt
         run: make fmt
       - name: vet
@@ -96,13 +89,6 @@ jobs:
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 1.20.x
-      - name: Restore Go cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: run test
         run: make test ENVTEST_K8S_VERSION=${{ matrix.kubernetes-version }}
 
@@ -121,13 +107,6 @@ jobs:
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
           go-version: 1.20.x
-      - name: Restore Go cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3.3.3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
       - name: build
         run: make build
       - name: Check if working tree is dirty

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ kustomize: ## Download kustomize locally if necessary.
 ENVTEST = $(GOBIN)/setup-envtest
 .PHONY: envtest
 envtest: ## Download envtest-setup locally if necessary.
-	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+        $(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17)
 
 # go-install-tool will 'go install' any package $2 and install it to $1
 define go-install-tool

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ lint: golangci-lint ## Run golangci-lint against code
 	$(GOLANGCI_LINT) run --timeout=2m ./...
 
 .PHONY: test
-test: manifests generate fmt vet tidy envtest ## Run tests.
+test: envtest manifests generate fmt vet tidy ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -v -coverprofile coverage.out -race
 
 ##@ Build
@@ -153,9 +153,9 @@ kustomize: ## Download kustomize locally if necessary.
 ENVTEST = $(GOBIN)/setup-envtest
 .PHONY: envtest
 envtest: ## Download envtest-setup locally if necessary.
-        $(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17)
+	$(call go-install-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17)
 
-# go-install-tool will 'go install' any package $2 and install it to $1
+# go-install-tool will 'go install' any package $2 and install it to $1.
 define go-install-tool
 @[ -f $(1) ] || { \
 set -e ;\

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ spec:
   address: http://keycloak-http.keycloak/auth
   authSecret:
     name: keycloak-admin
-  interval: 10m
+  interval: 1h
+  timeout: 5m0s
   realm:
     accessCodeLifespan: 60
     accessCodeLifespanLogin: 1800
@@ -168,7 +169,8 @@ spec:
     name: keycloak-admin
     passwordField: password
     userField: username
-  interval: 10m
+  interval: 1h
+  timeout: 5m0s
   suspend: false
   realm:
     accessCodeLifespan: 60
@@ -212,7 +214,8 @@ spec:
   address: http://keycloak-http.keycloak/auth
   authSecret:
     name: keycloak-admin
-  interval: 10m
+  interval: 1h
+  timeout: 5m0s
   realm:
     accessCodeLifespan: 60
     accessCodeLifespanLogin: 1800
@@ -268,7 +271,8 @@ spec:
   address: http://keycloak-http.keycloak/auth
   authSecret:
     name: keycloak-admin
-  interval: 10m
+  interval: 1h
+  timeout: 5m0s
   realm:
     accessCodeLifespan: 60
     accessCodeLifespanLogin: 1800

--- a/api/v1beta1/keycloakrealm_types.go
+++ b/api/v1beta1/keycloakrealm_types.go
@@ -62,6 +62,10 @@ type KeycloakRealmSpec struct {
 	// +optional
 	Interval *metav1.Duration `json:"interval,omitempty"`
 
+	// Timeout
+	// +optional
+	Timeout *metav1.Duration `json:"timeout,omitempty"`
+
 	// Suspend reconciliation
 	// +optional
 	Suspend bool `json:"suspend,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1271,6 +1271,11 @@ func (in *KeycloakRealmSpec) DeepCopyInto(out *KeycloakRealmSpec) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.ReconcilerTemplate != nil {
 		in, out := &in.ReconcilerTemplate, &out.ReconcilerTemplate
 		*out = new(ReconcilerTemplate)

--- a/chart/keycloak-controller/crds/keycloak.infra.doodle.com_keycloakrealms.yaml
+++ b/chart/keycloak-controller/crds/keycloak.infra.doodle.com_keycloakrealms.yaml
@@ -9096,6 +9096,9 @@ spec:
               suspend:
                 description: Suspend reconciliation
                 type: boolean
+              timeout:
+                description: Timeout
+                type: string
               version:
                 description: Version is the keycloak version
                 type: string

--- a/config/base/crd/bases/keycloak.infra.doodle.com_keycloakrealms.yaml
+++ b/config/base/crd/bases/keycloak.infra.doodle.com_keycloakrealms.yaml
@@ -9096,6 +9096,9 @@ spec:
               suspend:
                 description: Suspend reconciliation
                 type: boolean
+              timeout:
+                description: Timeout
+                type: string
               version:
                 description: Version is the keycloak version
                 type: string

--- a/internal/controllers/keycloakrealm_controller_test.go
+++ b/internal/controllers/keycloakrealm_controller_test.go
@@ -43,8 +43,8 @@ func needStatus(reconciledInstance *v1beta1.KeycloakRealm, expectedStatus *v1bet
 
 var _ = Describe("KeycloakRealm controller", func() {
 	const (
-		timeout  = time.Second * 10
-		interval = time.Millisecond * 600
+		timeout  = time.Second * 5
+		interval = time.Millisecond * 50
 	)
 
 	When("reconciling a suspendended KeycloakRealm", func() {
@@ -1691,6 +1691,138 @@ var _ = Describe("KeycloakRealm controller", func() {
 			}, timeout, interval).Should(BeNil())
 
 			Expect(string(secret.Data["realm.json"])).Should(Equal(fmt.Sprintf(`{"realm":"%s","users":[{"username":"%s","enabled":true}],"components":null,"requiredActions":null}`, realm.Name, userName)))
+		})
+	})
+
+	When("a realm reconciler runs into spec.timeout", func() {
+		realmName := fmt.Sprintf("realm-%s", rand.String(5))
+
+		It("recreates the reconciler with a new secret", func() {
+			By("creating a new KeycloakRealm")
+			ctx := context.Background()
+
+			authSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("auth-%s", rand.String(5)),
+					Namespace: "default",
+				},
+				StringData: map[string]string{
+					"username": "kc-user",
+					"password": "kc-password",
+				},
+			}
+
+			Expect(k8sClient.Create(ctx, authSecret)).Should(Succeed())
+
+			realm := &v1beta1.KeycloakRealm{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      realmName,
+					Namespace: "default",
+				},
+				Spec: v1beta1.KeycloakRealmSpec{
+					Interval: &metav1.Duration{Duration: time.Second * 100},
+					Timeout:  &metav1.Duration{Duration: time.Second * 100},
+					Version:  "22.0.1",
+					AuthSecret: v1beta1.SecretReference{
+						Name: authSecret.Name,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, realm)).Should(Succeed())
+
+			By("waiting for the reconciliation")
+			instanceLookupKey := types.NamespacedName{Name: realmName, Namespace: "default"}
+			reconciledInstance := &v1beta1.KeycloakRealm{}
+
+			expectedStatus := &v1beta1.KeycloakRealmStatus{
+				ObservedGeneration: 1,
+				Conditions: []metav1.Condition{
+					{
+						Type:    v1beta1.ConditionReady,
+						Status:  metav1.ConditionUnknown,
+						Reason:  "Progressing",
+						Message: "Reconciliation in progress",
+					},
+					{
+						Type:   v1beta1.ConditionReconciling,
+						Status: metav1.ConditionTrue,
+						Reason: "Progressing",
+					},
+				},
+			}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, instanceLookupKey, reconciledInstance)
+				if err != nil {
+					return false
+				}
+
+				return needStatus(reconciledInstance, expectedStatus)
+			}, timeout, interval).Should(BeTrue())
+
+		})
+
+		It("transitions into unready once the reconciler pod reached the timeout", func() {
+			reconciledInstance := &v1beta1.KeycloakRealm{}
+			instanceLookupKey := types.NamespacedName{Name: realmName, Namespace: "default"}
+			Expect(k8sClient.Get(ctx, instanceLookupKey, reconciledInstance)).Should(Succeed())
+
+			By("container shall be running for 500s")
+			pod := &corev1.Pod{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      reconciledInstance.Status.Reconciler,
+				Namespace: reconciledInstance.Namespace,
+			}, pod)).Should(Succeed())
+
+			pod.Status.ContainerStatuses = []corev1.ContainerStatus{
+				{
+					Name: "keycloak-config-cli",
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{
+							StartedAt: metav1.NewTime(time.Now().Add(time.Second * -500)),
+						},
+					},
+				},
+			}
+
+			Expect(k8sClient.Status().Update(ctx, pod)).Should(Succeed())
+
+			By("waiting for the reconciliation")
+			expectedStatus := &v1beta1.KeycloakRealmStatus{
+				ObservedGeneration: 1,
+				Conditions: []metav1.Condition{
+					{
+						Type:    v1beta1.ConditionReady,
+						Status:  metav1.ConditionFalse,
+						Reason:  "ReconciliationFailed",
+						Message: "reconciler timeout reached",
+					},
+				},
+			}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, instanceLookupKey, reconciledInstance)
+				if err != nil {
+					return false
+				}
+
+				return needStatus(reconciledInstance, expectedStatus)
+			}, timeout, interval).Should(BeTrue())
+
+			By("making sure the reconciler pod is gone")
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      reconciledInstance.Status.Reconciler,
+				Namespace: reconciledInstance.Namespace,
+			}, pod)).Should(Not(BeNil()))
+
+			Expect(reconciledInstance.Status.Reconciler).Should(Equal(""))
+
+			By("making sure the realm secret is gone")
+			var secret *corev1.Secret
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      reconciledInstance.Status.Reconciler,
+				Namespace: reconciledInstance.Namespace,
+			}, secret)).Should(Not(BeNil()))
 		})
 	})
 })

--- a/internal/controllers/keycloakrealm_controller_test.go
+++ b/internal/controllers/keycloakrealm_controller_test.go
@@ -43,7 +43,7 @@ func needStatus(reconciledInstance *v1beta1.KeycloakRealm, expectedStatus *v1bet
 
 var _ = Describe("KeycloakRealm controller", func() {
 	const (
-		timeout  = time.Second * 5
+		timeout  = time.Second * 10
 		interval = time.Millisecond * 50
 	)
 


### PR DESCRIPTION
## Current situation
A realm might not get reconciled if the specs do not change. This change was not intended and shall be changed.
Despite that a realm reconciler might get stuck and there is currently no way to set a timeout.

## Proposal
* Remove realm hash comparison which intented to avoid too manny reconciles. However this added to the issue that changes done only at kc are not reverted.
* Add labels to the realm pod and realm secret
* Add spec.timeout. The timeout only happens if the keycloak-config-cli container from the realm reconciler pod is running longer that the timeout configured. Once the timeout was
reacheched the reconciliation of the realm is aborted and gets requeued.
