### PR TITLE
fix: runtime and test race conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/base/crd/bases
+	cp config/base/crd/bases/* chart/keycloak-controller/crds/
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
@@ -138,7 +139,6 @@ CONTROLLER_GEN = $(GOBIN)/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-install-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.16.1)
-	cp config/base/crd/bases/* chart/keycloak-controller/crds/
 
 GOLANGCI_LINT = $(GOBIN)/golangci-lint
 .PHONY: golangci-lint

--- a/api/v1beta1/keycloakrealm_types.go
+++ b/api/v1beta1/keycloakrealm_types.go
@@ -142,18 +142,8 @@ type KeycloakRealmStatus struct {
 	// ObservedGeneration is the last generation reconciled by the controller
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// ObservedSHA256 is a SHA256 hash over the realm and all sub resources
-	ObservedSHA256 string `json:"observedSHA256,omitempty"`
-
-	// LastExececutionOutput failed requests
-	// +optional
-	LastExececutionOutput string `json:"lastExececutionOutput,omitempty"`
-
 	// Reconciler is the reconciler pod while a reconciliation is in progress
 	Reconciler string `json:"reconciler,omitempty"`
-
-	// LastReconcileDuration is the total time the reconcile of the realm took
-	LastReconcileDuration metav1.Duration `json:"lastReconcileDuration,omitempty"`
 
 	// LastFailedRequests failed requests
 	// +optional

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -1313,7 +1313,6 @@ func (in *KeycloakRealmStatus) DeepCopyInto(out *KeycloakRealmStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	out.LastReconcileDuration = in.LastReconcileDuration
 	if in.LastFailedRequests != nil {
 		in, out := &in.LastFailedRequests, &out.LastFailedRequests
 		*out = make([]RequestStatus, len(*in))

--- a/chart/keycloak-controller/crds/keycloak.infra.doodle.com_keycloakrealms.yaml
+++ b/chart/keycloak-controller/crds/keycloak.infra.doodle.com_keycloakrealms.yaml
@@ -9544,9 +9544,6 @@ spec:
                   - type
                   type: object
                 type: array
-              lastExececutionOutput:
-                description: LastExececutionOutput failed requests
-                type: string
               lastFailedRequests:
                 description: LastFailedRequests failed requests
                 items:
@@ -9569,19 +9566,11 @@ spec:
                       type: string
                   type: object
                 type: array
-              lastReconcileDuration:
-                description: LastReconcileDuration is the total time the reconcile
-                  of the realm took
-                type: string
               observedGeneration:
                 description: ObservedGeneration is the last generation reconciled
                   by the controller
                 format: int64
                 type: integer
-              observedSHA256:
-                description: ObservedSHA256 is a SHA256 hash over the realm and all
-                  sub resources
-                type: string
               reconciler:
                 description: Reconciler is the reconciler pod while a reconciliation
                   is in progress

--- a/config/base/crd/bases/keycloak.infra.doodle.com_keycloakrealms.yaml
+++ b/config/base/crd/bases/keycloak.infra.doodle.com_keycloakrealms.yaml
@@ -9544,9 +9544,6 @@ spec:
                   - type
                   type: object
                 type: array
-              lastExececutionOutput:
-                description: LastExececutionOutput failed requests
-                type: string
               lastFailedRequests:
                 description: LastFailedRequests failed requests
                 items:
@@ -9569,19 +9566,11 @@ spec:
                       type: string
                   type: object
                 type: array
-              lastReconcileDuration:
-                description: LastReconcileDuration is the total time the reconcile
-                  of the realm took
-                type: string
               observedGeneration:
                 description: ObservedGeneration is the last generation reconciled
                   by the controller
                 format: int64
                 type: integer
-              observedSHA256:
-                description: ObservedSHA256 is a SHA256 hash over the realm and all
-                  sub resources
-                type: string
               reconciler:
                 description: Reconciler is the reconciler pod while a reconciliation
                   is in progress

--- a/internal/controllers/keycloakrealm_controller_test.go
+++ b/internal/controllers/keycloakrealm_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("KeycloakRealm controller", func() {
 		interval = time.Millisecond * 50
 	)
 
-	When("reconciling a suspendended KeycloakRealm", func() {
+	When("reconciling a suspended KeycloakRealm", func() {
 		realmName := fmt.Sprintf("realm-%s", rand.String(5))
 
 		It("should not update the status", func() {
@@ -190,7 +190,6 @@ var _ = Describe("KeycloakRealm controller", func() {
 			Expect(pod.Spec.Containers[0].Image).Should(Equal("test:latest-22.0.1"))
 			Expect(pod.Spec.Containers[0].Env).Should(Equal(envs))
 			Expect(reconciledInstance.Status.SubResourceCatalog).Should(HaveLen(0))
-			Expect(reconciledInstance.Status.ObservedSHA256).Should(HaveLen(64))
 
 			By("validating the realm secret")
 			secret := corev1.Secret{}
@@ -236,7 +235,7 @@ var _ = Describe("KeycloakRealm controller", func() {
 						Type:    v1beta1.ConditionReady,
 						Status:  metav1.ConditionTrue,
 						Reason:  "ReconciliationSucceeded",
-						Message: fmt.Sprintf("reconiler %s terminated with code 0", pod.Name),
+						Message: fmt.Sprintf("reconciler %s terminated with code 0", pod.Name),
 					},
 				},
 			}
@@ -247,7 +246,7 @@ var _ = Describe("KeycloakRealm controller", func() {
 					return false
 				}
 
-				return needStatus(reconciledInstance, expectedStatus)
+				return needStatus(reconciledInstance, expectedStatus) && reconciledInstance.Status.Reconciler == ""
 			}, timeout, interval).Should(BeTrue())
 
 			By("making sure the reconciler pod is gone")
@@ -266,7 +265,6 @@ var _ = Describe("KeycloakRealm controller", func() {
 			}, secret)).Should(Not(BeNil()))
 		})
 	})
-
 	When("a realm with no version is reconciled", func() {
 		realmName := fmt.Sprintf("realm-%s", rand.String(5))
 
@@ -1029,7 +1027,7 @@ var _ = Describe("KeycloakRealm controller", func() {
 					return false
 				}
 
-				return needStatus(reconciledInstance, expectedStatus) && reconciledInstance.Status.Reconciler != beforeUpdateStatus.Reconciler
+				return needStatus(reconciledInstance, expectedStatus) && reconciledInstance.Status.Reconciler != beforeUpdateStatus.Reconciler && reconciledInstance.Status.Reconciler != ""
 			}, timeout, interval).Should(BeTrue())
 
 			By("making sure the resource catalog is correct")
@@ -1162,7 +1160,7 @@ var _ = Describe("KeycloakRealm controller", func() {
 					return false
 				}
 
-				return needStatus(reconciledInstance, expectedStatus) && reconciledInstance.Status.Reconciler != beforeUpdateStatus.Reconciler
+				return needStatus(reconciledInstance, expectedStatus) && reconciledInstance.Status.Reconciler != beforeUpdateStatus.Reconciler && reconciledInstance.Status.Reconciler != ""
 			}, timeout, interval).Should(BeTrue())
 
 			By("making sure the resource catalog is correct")
@@ -1296,7 +1294,7 @@ var _ = Describe("KeycloakRealm controller", func() {
 					return false
 				}
 
-				return needStatus(reconciledInstance, expectedStatus) && reconciledInstance.Status.Reconciler != beforeUpdateStatus.Reconciler
+				return needStatus(reconciledInstance, expectedStatus) && reconciledInstance.Status.Reconciler != beforeUpdateStatus.Reconciler && reconciledInstance.Status.Reconciler != ""
 			}, timeout, interval).Should(BeTrue())
 
 			By("making sure the resource catalog is correct")
@@ -1482,15 +1480,17 @@ var _ = Describe("KeycloakRealm controller", func() {
 					return false
 				}
 
-				return beforeChangeStatus.Reconciler != reconciledInstance.Status.Reconciler
+				return beforeChangeStatus.Reconciler != reconciledInstance.Status.Reconciler && reconciledInstance.Status.Reconciler != ""
 			}, timeout, interval).Should(BeTrue())
 
 			By("making sure there is a reconciler pod")
 			pod := &corev1.Pod{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{
-				Name:      reconciledInstance.Status.Reconciler,
-				Namespace: reconciledInstance.Namespace,
-			}, pod)).Should(Succeed())
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{
+					Name:      reconciledInstance.Status.Reconciler,
+					Namespace: reconciledInstance.Namespace,
+				}, pod)
+			}, timeout, interval).Should(BeNil())
 
 			Expect(pod.Spec.Containers[1].Image).Should(Equal("new-image:v1"))
 		})
@@ -1516,7 +1516,7 @@ var _ = Describe("KeycloakRealm controller", func() {
 					return false
 				}
 
-				return beforeChangeStatus.Reconciler != reconciledInstance.Status.Reconciler
+				return beforeChangeStatus.Reconciler != reconciledInstance.Status.Reconciler && reconciledInstance.Status.Reconciler != ""
 			}, timeout, interval).Should(BeTrue())
 		})
 	})
@@ -1677,7 +1677,7 @@ var _ = Describe("KeycloakRealm controller", func() {
 					return false
 				}
 
-				return needStatus(reconciledInstance, expectedStatus) && reconciledInstance.Status.Reconciler != beforeUpdateStatus.Reconciler
+				return needStatus(reconciledInstance, expectedStatus) && reconciledInstance.Status.Reconciler != beforeUpdateStatus.Reconciler && reconciledInstance.Status.Reconciler != ""
 			}, timeout, interval).Should(BeTrue())
 
 			By("making sure the resource catalog is correct")
@@ -1814,7 +1814,6 @@ var _ = Describe("KeycloakRealm controller", func() {
 
 					Eventually(func() bool {
 						err := k8sClient.Get(ctx, instanceLookupKey, reconciledInstance)
-						fmt.Printf("%#v\n\n", reconciledInstance.Status.Conditions)
 						if err != nil {
 							return false
 						}

--- a/internal/controllers/keycloakrealm_controller_test.go
+++ b/internal/controllers/keycloakrealm_controller_test.go
@@ -233,9 +233,10 @@ var _ = Describe("KeycloakRealm controller", func() {
 				ObservedGeneration: 1,
 				Conditions: []metav1.Condition{
 					{
-						Type:   v1beta1.ConditionReady,
-						Status: metav1.ConditionTrue,
-						Reason: "ReconciliationSucceeded",
+						Type:    v1beta1.ConditionReady,
+						Status:  metav1.ConditionTrue,
+						Reason:  "ReconciliationSucceeded",
+						Message: fmt.Sprintf("reconiler %s terminated with code 0", pod.Name),
 					},
 				},
 			}


### PR DESCRIPTION
## Current situation
Unit tests fail at random. This due the fact that the controller code is not that robustly implemented.
After the reconcile it stores the state in .Status and at the same time another reconcile loop is triggered from with a stale resource from 
the client cache because it was triggered from the delete pod event which was issued before the status updates.

## Proposal
Refactor code to be more robust in general. Meaning refactor into different phases which each will exit the reconciliation and start from the beginning if required.
This includes:
1. Unlink stale reconciler from the realm status
2. Delete reconciler pod if it is stale
3. Garbage collect reconciler pod
4. Skip reconciliation if last sucessful reconciliation is before spec.interval + now()
5. Handle container status of a reconciler
6. Create a new reconciler pod
