### PR TITLE
fix: create reconciler if new sub resources are added

### DIFF
--- a/api/v1beta1/keycloakrealm_types.go
+++ b/api/v1beta1/keycloakrealm_types.go
@@ -143,6 +143,9 @@ type KeycloakRealmStatus struct {
 	// ObservedGeneration is the last generation reconciled by the controller
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
+	// ObservedSHA256 is the last realm checksum reconciled by the controller
+	ObservedSHA256 string `json:"observedSHA256,omitempty"`
+
 	// Reconciler is the reconciler pod while a reconciliation is in progress
 	Reconciler string `json:"reconciler,omitempty"`
 

--- a/chart/keycloak-controller/crds/keycloak.infra.doodle.com_keycloakrealms.yaml
+++ b/chart/keycloak-controller/crds/keycloak.infra.doodle.com_keycloakrealms.yaml
@@ -9571,6 +9571,10 @@ spec:
                   by the controller
                 format: int64
                 type: integer
+              observedSHA256:
+                description: ObservedSHA256 is the last realm checksum reconciled
+                  by the controller
+                type: string
               reconciler:
                 description: Reconciler is the reconciler pod while a reconciliation
                   is in progress

--- a/config/base/crd/bases/keycloak.infra.doodle.com_keycloakrealms.yaml
+++ b/config/base/crd/bases/keycloak.infra.doodle.com_keycloakrealms.yaml
@@ -9571,6 +9571,10 @@ spec:
                   by the controller
                 format: int64
                 type: integer
+              observedSHA256:
+                description: ObservedSHA256 is the last realm checksum reconciled
+                  by the controller
+                type: string
               reconciler:
                 description: Reconciler is the reconciler pod while a reconciliation
                   is in progress

--- a/internal/controllers/keycloakrealm_controller.go
+++ b/internal/controllers/keycloakrealm_controller.go
@@ -334,7 +334,7 @@ func (r *KeycloakRealmReconciler) reconcile(ctx context.Context, realm infrav1be
 	}
 
 	// rate limiter
-	if readyCondition != nil && readyCondition.Status == metav1.ConditionTrue && (realm.Spec.Interval == nil || time.Since(readyCondition.LastTransitionTime.Time) < realm.Spec.Interval.Duration) && realm.Generation == readyCondition.ObservedGeneration {
+	if readyCondition != nil && readyCondition.Status == metav1.ConditionTrue && (realm.Spec.Interval == nil || time.Since(readyCondition.LastTransitionTime.Time) < realm.Spec.Interval.Duration) && checksum == realm.Status.ObservedSHA256 {
 		logger.V(1).Info("skip reconciliation, last transition time too recent")
 
 		if realm.Spec.Interval != nil {
@@ -345,6 +345,8 @@ func (r *KeycloakRealmReconciler) reconcile(ctx context.Context, realm infrav1be
 			return realm, ctrl.Result{}, nil
 		}
 	}
+
+	realm.Status.ObservedSHA256 = checksum
 
 	// handle reconciler pod state
 	if podErr == nil && pod.Name != "" {


### PR DESCRIPTION
## Current situation
No reconciler is created until spec.interval is reached (if set) if a new keycloakclient or user have been added.
This is because the controller does not create it on purpose to avoid an infite reconcile loop.

## Proposal
This does not happen if the realm itself is changed. The problem is that curently for this check the realm generation is used however
this does not change for added/changed clients nor users.

This pr adds a checkum field which is now used for this check instead.
