### PR TITLE
ci: fix goreleaser legacy config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,11 +18,11 @@ builds:
 archives:
 - id: manager
   name_template: "manager_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  builds:
+  ids:
   - manager
 - id: proxy
   name_template: "proxy_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-  builds:
+  ids:
   - proxy
 
 checksum:


### PR DESCRIPTION
## Current situation
renovate merged an incompatible upgrade of the goreleaser action.

## Proposal
Align goreleaser config and replace removed fields.
