### PR TITLE
ci: align gorelaser with latest cosign version

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -133,13 +133,10 @@ docker_manifests:
 
 signs:
 - cmd: cosign
-  certificate: "${artifact}.pem"
-  env:
-  - COSIGN_EXPERIMENTAL=1
+  signature: "${artifact}.sigstore.json"
   args:
   - sign-blob
-  - "--output-certificate=${certificate}"
-  - "--output-signature=${signature}"
+  - "--bundle=${signature}"
   - --yes
   - "${artifact}"
   artifacts: checksum
@@ -147,8 +144,6 @@ signs:
 
 docker_signs:
   - cmd: cosign
-    env:
-    - COSIGN_EXPERIMENTAL=1
     artifacts: all
     output: true
     args:


### PR DESCRIPTION
## Current situation
<!--- Shortly describe the current situation -->

## Proposal
<!--- Describe what this PR is intended to achieve -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates GoReleaser signing to use cosign's current keyless bundle format instead of separate certificate and signature files. This removes the `COSIGN_EXPERIMENTAL` environment variable and switches both checksum and docker signing to `--bundle`, producing a single `.sigstore.json` per artifact.

<sup>Written for commit 42b5b3490f5641f827c9dcb41bf707bb2a28cdb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DoodleScheduling/keycloak-controller/pull/721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated artifact and container signing configuration to use modern Sigstore bundles.
  * Removed experimental signing settings and certificate output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->